### PR TITLE
feat: Go 1.24 bytes/strings イテレータ対応の動作検証

### DIFF
--- a/1_24/bytes_strings_iterator/01_iter_seq_type_test.go
+++ b/1_24/bytes_strings_iterator/01_iter_seq_type_test.go
@@ -1,0 +1,26 @@
+package bytes_strings_iterator_test
+
+import (
+	"iter"
+	"testing"
+)
+
+// TestIterSeq_WhatIsIt は iter.Seq の実体を確認する。
+// iter.Seq[V] は func(yield func(V) bool) という関数型のエイリアス。
+// for-range に渡せる関数であれば何でも iter.Seq として扱える。
+func TestIterSeq_WhatIsIt(t *testing.T) {
+	// iter.Seq[string] の実体: yield を受け取り、値を1つずつ渡す関数
+	var seq iter.Seq[string] = func(yield func(string) bool) {
+		for _, s := range []string{"a", "b", "c"} {
+			if !yield(s) {
+				return // yield が false を返したら break された合図
+			}
+		}
+	}
+
+	var got []string
+	for s := range seq {
+		got = append(got, s)
+	}
+	t.Logf("内容: %q", got)
+}

--- a/1_24/bytes_strings_iterator/02_iter_seq_yield_break_test.go
+++ b/1_24/bytes_strings_iterator/02_iter_seq_yield_break_test.go
@@ -1,0 +1,26 @@
+package bytes_strings_iterator_test
+
+import (
+	"iter"
+	"testing"
+)
+
+// TestIterSeq_YieldAndBreak は yield と break の関係を確認する。
+// break すると yield が false を返し、イテレータ側で処理を止められる。
+func TestIterSeq_YieldAndBreak(t *testing.T) {
+	var seq iter.Seq[string] = func(yield func(string) bool) {
+		for _, s := range []string{"a", "b", "c", "d", "e"} {
+			t.Logf("yield: %q", s)
+			if !yield(s) {
+				t.Logf("break を検知 → イテレータ終了")
+				return
+			}
+		}
+	}
+
+	for s := range seq {
+		if s == "b" {
+			break // "b" の次は yield すら呼ばれない
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/03_iter_seq_custom_lines_test.go
+++ b/1_24/bytes_strings_iterator/03_iter_seq_custom_lines_test.go
@@ -1,0 +1,35 @@
+package bytes_strings_iterator_test
+
+import (
+	"iter"
+	"strings"
+	"testing"
+)
+
+// TestIterSeq_CustomLines は strings.Lines の実際の実装を再現したカスタムイテレータ。
+// IndexByte で改行位置を直接取得してスライスする実装になっている。
+// 参考: https://github.com/golang/go/blob/master/src/strings/iter.go
+func TestIterSeq_CustomLines(t *testing.T) {
+	myLines := func(s string) iter.Seq[string] {
+		return func(yield func(string) bool) {
+			for len(s) > 0 {
+				var line string
+				if i := strings.IndexByte(s, '\n'); i >= 0 {
+					line, s = s[:i+1], s[i+1:]
+				} else {
+					line, s = s, ""
+				}
+				if !yield(line) {
+					return
+				}
+			}
+		}
+	}
+
+	s := "first\nsecond\nthird"
+	var got []string
+	for line := range myLines(s) {
+		got = append(got, line)
+	}
+	t.Logf("内容: %q", got)
+}

--- a/1_24/bytes_strings_iterator/04_strings_lines_vs_strings_split_test.go
+++ b/1_24/bytes_strings_iterator/04_strings_lines_vs_strings_split_test.go
@@ -1,0 +1,48 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsLines_OldSplit は従来の strings.Split を使った行の走査。
+func TestStringsLines_OldSplit(t *testing.T) {
+	s := "apple\nbanana\ncherry"
+	want := []string{"apple", "banana", "cherry"}
+
+	got := strings.Split(s, "\n")
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("行数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStringsLines_New は Go 1.24 で追加された strings.Lines を使った行の走査。
+// strings.Lines は改行文字を含んで yield する。
+func TestStringsLines_New(t *testing.T) {
+	s := "apple\nbanana\ncherry"
+	want := []string{"apple\n", "banana\n", "cherry"}
+
+	var got []string
+	for line := range strings.Lines(s) {
+		got = append(got, line)
+	}
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("行数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/05_strings_lines_trailing_newline_vs_strings_split_trailing_newline_test.go
+++ b/1_24/bytes_strings_iterator/05_strings_lines_trailing_newline_vs_strings_split_trailing_newline_test.go
@@ -1,0 +1,31 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsSplit_TrailingNewline は strings.Split の末尾改行の挙動を確認する。
+// 末尾に \n がある場合、Split は余分な空文字列を末尾に生成する。
+func TestStringsSplit_TrailingNewline(t *testing.T) {
+	s := "first\nsecond\nthird\n" // 末尾の改行あり
+
+	got := strings.Split(s, "\n")
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["first" "second" "third" ""] 末尾に空文字列が入る
+}
+
+// TestStringsLines_TrailingNewline は strings.Lines の末尾改行の挙動を確認する。
+// 末尾に \n があっても余分な空文字列は生成されない。
+func TestStringsLines_TrailingNewline(t *testing.T) {
+	s := "first\nsecond\nthird\n" // 末尾の改行あり
+
+	var got []string
+	for line := range strings.Lines(s) {
+		got = append(got, line)
+	}
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["first\n" "second\n" "third\n"] 末尾の空文字列なし
+}

--- a/1_24/bytes_strings_iterator/06_strings_lines_break_vs_strings_split_break_test.go
+++ b/1_24/bytes_strings_iterator/06_strings_lines_break_vs_strings_split_break_test.go
@@ -1,0 +1,45 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsSplit_Break は strings.Split を使った早期終了の例。
+// break しても Split の時点で 5行分の []string がすでに確保されている。
+func TestStringsSplit_Break(t *testing.T) {
+	s := "line1\nline2\nline3\nline4\nline5\n"
+
+	// ループに入る前に全行分のスライスが確保される
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	t.Logf("ループ前に確保済みの行数: %d", len(lines))
+
+	var processed []string
+	for _, line := range lines {
+		processed = append(processed, line)
+		if len(processed) == 2 {
+			break
+		}
+	}
+
+	t.Logf("実際に処理した行: %v", processed)
+	t.Logf("確保されたが処理しなかった行: %v", lines[len(processed):])
+}
+
+// TestStringsLines_Break は break によるイテレータの早期終了を確認する。
+// s には 5行あるが、2行目で break するため 2行分しか yield されない。
+func TestStringsLines_Break(t *testing.T) {
+	s := "line1\nline2\nline3\nline4\nline5\n"
+
+	var processed []string
+	for line := range strings.Lines(s) {
+		processed = append(processed, strings.TrimRight(line, "\n"))
+		if len(processed) == 2 {
+			break
+		}
+	}
+
+	t.Logf("実際に処理した行: %v", processed)
+	// strings.Lines はイテレータなので未処理の行を取り出す手段がない
+	// → break した時点で line3〜line5 は yield すら行われていない
+}

--- a/1_24/bytes_strings_iterator/07_strings_split_seq_vs_strings_split_test.go
+++ b/1_24/bytes_strings_iterator/07_strings_split_seq_vs_strings_split_test.go
@@ -1,0 +1,48 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsSplitSeq_OldSplit は従来の strings.Split を使った文字列の分割。
+func TestStringsSplitSeq_OldSplit(t *testing.T) {
+	s := "a,b,c,d"
+	want := []string{"a", "b", "c", "d"}
+
+	got := strings.Split(s, ",")
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStringsSplitSeq_New は Go 1.24 で追加された strings.SplitSeq を使った文字列の分割。
+// strings.Split と異なり、[]string を事前確保せず 1要素ずつ yield する。
+func TestStringsSplitSeq_New(t *testing.T) {
+	s := "a,b,c,d"
+	want := []string{"a", "b", "c", "d"}
+
+	var got []string
+	for part := range strings.SplitSeq(s, ",") {
+		got = append(got, part)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/08_strings_split_after_seq_vs_strings_split_after_test.go
+++ b/1_24/bytes_strings_iterator/08_strings_split_after_seq_vs_strings_split_after_test.go
@@ -1,0 +1,49 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsSplitAfterSeq_OldSplitAfter は従来の strings.SplitAfter を使った分割。
+// sep を含んだまま分割する。
+func TestStringsSplitAfterSeq_OldSplitAfter(t *testing.T) {
+	s := "a,b,c"
+	want := []string{"a,", "b,", "c"}
+
+	got := strings.SplitAfter(s, ",")
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStringsSplitAfterSeq_New は Go 1.24 で追加された strings.SplitAfterSeq を使った分割。
+// SplitAfter と同様に sep を含んだまま yield するが、[]string を事前確保しない。
+func TestStringsSplitAfterSeq_New(t *testing.T) {
+	s := "a,b,c"
+	want := []string{"a,", "b,", "c"}
+
+	var got []string
+	for part := range strings.SplitAfterSeq(s, ",") {
+		got = append(got, part)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/09_strings_fields_seq_vs_strings_fields_test.go
+++ b/1_24/bytes_strings_iterator/09_strings_fields_seq_vs_strings_fields_test.go
@@ -1,0 +1,48 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsFieldsSeq_OldFields は従来の strings.Fields を使った空白区切りの分割。
+func TestStringsFieldsSeq_OldFields(t *testing.T) {
+	s := "  foo   bar\tbaz  "
+	want := []string{"foo", "bar", "baz"}
+
+	got := strings.Fields(s)
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStringsFieldsSeq_New は Go 1.24 で追加された strings.FieldsSeq を使った空白区切りの分割。
+// strings.Fields と同じ結果を返すが、[]string を事前確保せず 1要素ずつ yield する。
+func TestStringsFieldsSeq_New(t *testing.T) {
+	s := "  foo   bar\tbaz  "
+	want := []string{"foo", "bar", "baz"}
+
+	var got []string
+	for field := range strings.FieldsSeq(s) {
+		got = append(got, field)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/10_strings_fields_seq_vs_strings_split_seq_consecutive_sep_test.go
+++ b/1_24/bytes_strings_iterator/10_strings_fields_seq_vs_strings_split_seq_consecutive_sep_test.go
@@ -1,0 +1,34 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringsSplitSeq_ConsecutiveSep は strings.SplitSeq の連続セパレータの挙動を確認する。
+// 連続したセパレータの間に空文字列が入る。
+func TestStringsSplitSeq_ConsecutiveSep(t *testing.T) {
+	s := "a,,b,,c"
+
+	var got []string
+	for part := range strings.SplitSeq(s, ",") {
+		got = append(got, part)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["a" "" "b" "" "c"] 連続する ,, の間に空文字列が入る
+}
+
+// TestStringsFieldsSeq_ConsecutiveSep は strings.FieldsSeq の連続セパレータの挙動を確認する。
+// 連続した空白はまとめて 1つの区切りとして扱われ、空文字列は生成されない。
+func TestStringsFieldsSeq_ConsecutiveSep(t *testing.T) {
+	s := "a  b  c"
+
+	var got []string
+	for field := range strings.FieldsSeq(s) {
+		got = append(got, field)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["a" "b" "c"] 連続する空白をまとめて区切るため空文字列なし
+}

--- a/1_24/bytes_strings_iterator/11_strings_fields_func_seq_vs_strings_fields_func_test.go
+++ b/1_24/bytes_strings_iterator/11_strings_fields_func_seq_vs_strings_fields_func_test.go
@@ -1,0 +1,50 @@
+package bytes_strings_iterator_test
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// TestStringsFieldsFuncSeq_OldFieldsFunc は従来の strings.FieldsFunc を使った任意条件での分割。
+// 数字を区切り文字として使用する。
+func TestStringsFieldsFuncSeq_OldFieldsFunc(t *testing.T) {
+	s := "abc123def456ghi"
+	want := []string{"abc", "def", "ghi"}
+
+	got := strings.FieldsFunc(s, unicode.IsDigit)
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStringsFieldsFuncSeq_New は Go 1.24 で追加された strings.FieldsFuncSeq を使った任意条件での分割。
+// strings.FieldsFunc と同じ結果を返すが、[]string を事前確保せず 1要素ずつ yield する。
+func TestStringsFieldsFuncSeq_New(t *testing.T) {
+	s := "abc123def456ghi"
+	want := []string{"abc", "def", "ghi"}
+
+	var got []string
+	for field := range strings.FieldsFuncSeq(s, unicode.IsDigit) {
+		got = append(got, field)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/12_bytes_lines_vs_bytes_split_test.go
+++ b/1_24/bytes_strings_iterator/12_bytes_lines_vs_bytes_split_test.go
@@ -1,0 +1,73 @@
+package bytes_strings_iterator_test
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBytesLines_OldSplit は従来の bytes.Split を使った行の走査。
+func TestBytesLines_OldSplit(t *testing.T) {
+	b := []byte("apple\nbanana\ncherry")
+	want := [][]byte{[]byte("apple"), []byte("banana"), []byte("cherry")}
+
+	got := bytes.Split(b, []byte("\n"))
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("行数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBytesLines_New は Go 1.24 で追加された bytes.Lines を使った行の走査。
+// bytes.Lines は改行文字を含んで yield する。
+func TestBytesLines_New(t *testing.T) {
+	b := []byte("apple\nbanana\ncherry")
+	want := [][]byte{[]byte("apple\n"), []byte("banana\n"), []byte("cherry")}
+
+	var got [][]byte
+	for line := range bytes.Lines(b) {
+		got = append(got, line)
+	}
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("行数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBytesLines_TrailingNewline は bytes.Split と bytes.Lines の末尾改行の挙動を比較する。
+// bytes.Split は末尾 \n により空スライスが末尾に入るが、bytes.Lines は入らない。
+func TestBytesSplit_TrailingNewline(t *testing.T) {
+	b := []byte("first\nsecond\nthird\n") // 末尾の改行あり
+
+	got := bytes.Split(b, []byte("\n"))
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["first" "second" "third" ""] 末尾に空スライスが入る
+}
+
+// TestBytesLines_TrailingNewline は bytes.Lines の末尾改行の挙動を確認する。
+// 末尾に \n があっても余分な空スライスは生成されない。
+func TestBytesLines_TrailingNewline(t *testing.T) {
+	b := []byte("first\nsecond\nthird\n") // 末尾の改行あり
+
+	var got [][]byte
+	for line := range bytes.Lines(b) {
+		got = append(got, line)
+	}
+	t.Logf("行数: %d", len(got))
+	t.Logf("内容: %q", got)
+	// → ["first\n" "second\n" "third\n"] 末尾の空スライスなし
+}

--- a/1_24/bytes_strings_iterator/13_bytes_split_seq_vs_bytes_split_test.go
+++ b/1_24/bytes_strings_iterator/13_bytes_split_seq_vs_bytes_split_test.go
@@ -1,0 +1,48 @@
+package bytes_strings_iterator_test
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBytesSplitSeq_OldSplit は従来の bytes.Split を使った分割。
+func TestBytesSplitSeq_OldSplit(t *testing.T) {
+	b := []byte("a,b,c,d")
+	want := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d")}
+
+	got := bytes.Split(b, []byte(","))
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBytesSplitSeq_New は Go 1.24 で追加された bytes.SplitSeq を使った分割。
+// bytes.Split と同じ結果を返すが、[][]byte を事前確保せず 1要素ずつ yield する。
+func TestBytesSplitSeq_New(t *testing.T) {
+	b := []byte("a,b,c,d")
+	want := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d")}
+
+	var got [][]byte
+	for part := range bytes.SplitSeq(b, []byte(",")) {
+		got = append(got, part)
+	}
+	t.Logf("要素数: %d", len(got))
+	t.Logf("内容: %q", got)
+
+	if len(got) != len(want) {
+		t.Fatalf("要素数: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("[%d]: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}

--- a/1_24/bytes_strings_iterator/go.mod
+++ b/1_24/bytes_strings_iterator/go.mod
@@ -1,0 +1,3 @@
+module github.com/tamaco489/go_sandbox/1_24/bytes_strings_iterator
+
+go 1.24


### PR DESCRIPTION
## Summary

- Go 1.24 で `bytes` / `strings` パッケージに追加されたイテレータ関数群の動作を検証するテストファイルを追加
- `iter.Seq` の基本的な仕組み (yield / break) から始まり、各関数の新旧比較まで 13 ファイルで段階的に確認できる構成

## Test plan

- [x] `go test ./...` が全テストパス済みであること
- [x] `strings.Lines` の末尾改行の挙動、break による早期終了が確認できること
- [x] `bytes.Lines` / `bytes.SplitSeq` の `[]byte` 版も同様に確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)